### PR TITLE
Add Workshoppa IPC provider (AddQueueItem, ClearQueue)

### DIFF
--- a/VIWI.Core/IPC/WorkshoppaIPC.cs
+++ b/VIWI.Core/IPC/WorkshoppaIPC.cs
@@ -1,0 +1,54 @@
+using Dalamud.Plugin.Ipc;
+using ECommons.DalamudServices;
+using System;
+using VIWI.Modules.Workshoppa;
+
+namespace VIWI.IPC;
+
+internal sealed class WorkshoppaIPC : IDisposable
+{
+    private const string Ipc_AddQueueItem = "VIWI.Workshoppa.AddQueueItem";
+    private const string Ipc_ClearQueue = "VIWI.Workshoppa.ClearQueue";
+
+    private ICallGateProvider<uint, int, bool>? _addQueueItem;
+    private ICallGateProvider<bool>? _clearQueue;
+
+    public void Register()
+    {
+        _addQueueItem = Svc.PluginInterface.GetIpcProvider<uint, int, bool>(Ipc_AddQueueItem);
+        _clearQueue = Svc.PluginInterface.GetIpcProvider<bool>(Ipc_ClearQueue);
+
+        _addQueueItem.RegisterFunc(AddQueueItem);
+        _clearQueue.RegisterFunc(ClearQueue);
+    }
+
+    public void Dispose()
+    {
+        try { _addQueueItem?.UnregisterFunc(); } catch { }
+        try { _clearQueue?.UnregisterFunc(); } catch { }
+        _addQueueItem = null;
+        _clearQueue = null;
+    }
+
+    private static bool AddQueueItem(uint workshopItemId, int quantity)
+    {
+        try
+        {
+            var mod = WorkshoppaModule.Instance;
+            if (mod == null || !WorkshoppaModule.Enabled) return false;
+            return mod.IpcAddQueueItem(workshopItemId, quantity);
+        }
+        catch { return false; }
+    }
+
+    private static bool ClearQueue()
+    {
+        try
+        {
+            var mod = WorkshoppaModule.Instance;
+            if (mod == null || !WorkshoppaModule.Enabled) return false;
+            return mod.IpcClearQueue();
+        }
+        catch { return false; }
+    }
+}

--- a/VIWI.Core/Modules/Workshoppa/WorkshoppaModule.cs
+++ b/VIWI.Core/Modules/Workshoppa/WorkshoppaModule.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using VIWI.Core;
+using VIWI.IPC;
 using VIWI.Modules.Workshoppa.External;
 using VIWI.Modules.Workshoppa.GameData;
 using VIWI.Modules.Workshoppa.Windows;
@@ -43,6 +44,7 @@ internal sealed partial class WorkshoppaModule : VIWIModuleBase<WorkshoppaConfig
     internal readonly IReadOnlyList<ushort> WorkshopTerritories =
         new ushort[] { 423, 424, 425, 653, 984 }.AsReadOnly();
 
+    private WorkshoppaIPC? _ipc;
     private ExternalPluginHandler _externalPluginHandler = null!;
     private WorkshopCache _workshopCache = null!;
     private GameStrings _gameStrings = null!;
@@ -114,10 +116,16 @@ internal sealed partial class WorkshoppaModule : VIWIModuleBase<WorkshoppaConfig
         AddonLifecycle.RegisterListener(AddonEvent.PostSetup, "Request", RequestPostSetup);
         AddonLifecycle.RegisterListener(AddonEvent.PostRefresh, "Request", RequestPostRefresh);
         AddonLifecycle.RegisterListener(AddonEvent.PostUpdate, "ContextIconMenu", ContextIconMenuPostReceiveEvent);
+
+        _ipc ??= new WorkshoppaIPC();
+        _ipc.Register();
     }
 
     public override void Disable()
     {
+        try { _ipc?.Dispose(); } catch { }
+        _ipc = null;
+
         _repairKitWindow?.DisableShopListeners();
         _ceruleumTankWindow?.DisableShopListeners();
         _grindstoneShopWindow?.DisableShopListeners();
@@ -488,6 +496,36 @@ internal sealed partial class WorkshoppaModule : VIWIModuleBase<WorkshoppaConfig
     {
         if (!_configuration.Enabled) return;
         ProcessCommand("/ws", "");
+    }
+
+    internal bool IpcAddQueueItem(uint workshopItemId, int quantity)
+    {
+        if (!_configuration.Enabled) return false;
+        if (workshopItemId == 0 || quantity <= 0) return false;
+
+        var craft = _workshopCache?.Crafts?.FirstOrDefault(x => x.WorkshopItemId == workshopItemId);
+        if (craft == null || craft.WorkshopItemId == 0) return false;
+
+        var existing = _configuration.ItemQueue.FirstOrDefault(x => x.WorkshopItemId == workshopItemId);
+        if (existing != null)
+            existing.Quantity += quantity;
+        else
+            _configuration.ItemQueue.Add(new WorkshoppaConfig.QueuedItem
+            {
+                WorkshopItemId = workshopItemId,
+                Quantity = quantity,
+            });
+
+        SaveConfig();
+        return true;
+    }
+
+    internal bool IpcClearQueue()
+    {
+        if (!_configuration.Enabled) return false;
+        _configuration.ItemQueue.Clear();
+        SaveConfig();
+        return true;
     }
 
     /*public void OpenRepairKit()


### PR DESCRIPTION
Hello!

First off, thank you for maintaining and adding all the new features to Workshoppa lately, and VIWI overall is awesome, it's been appreciated!

I was hoping, can you please consider adding this IPC (or your own version) so that my plugin, FCCH, can communicate with yours? Essentially, it just allows sending items to the Workshoppa queue and clear it via IPC.

I've kept the changes as minimal and non-intrusive as possible. I've attached a small gif of it in action (˶>⩊<˶)💕

<img width="1006" height="680" alt="ffxiv_dx11_05_2026_1778066096+ 941" src="https://github.com/user-attachments/assets/bfd41c82-e7ff-46ad-a3bd-6ea679fa9ec0" />
